### PR TITLE
vendor: black theme fix

### DIFF
--- a/themes/Black/SystemUI/res/values/styles.xml
+++ b/themes/Black/SystemUI/res/values/styles.xml
@@ -7,7 +7,7 @@
         <item name="android:colorAccent">@*android:color/accent_device_default_dark</item>
         <item name="android:colorControlNormal">?android:attr/textColorPrimary</item>
         <item name="android:colorBackgroundFloating">@*android:color/black</item>
-        <item name="android:panelColorBackground">@*android:color/material_grey_800</item>
+        <item name="android:panelColorBackground">@*android:color/black</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Makes background of settings icon in volume dialog black
this resource is used only by it so there aren't any downsides of that change